### PR TITLE
Refactor `LighthouseClient` towards asynchronous streams

### DIFF
--- a/Sources/LighthouseDemo/LighthouseDemo.swift
+++ b/Sources/LighthouseDemo/LighthouseDemo.swift
@@ -26,22 +26,24 @@ struct LighthouseDemo: ParsableCommand {
         let auth = Authentication(username: username, token: token)
         let lh = Lighthouse(authentication: auth, url: url)
 
-        // Handle incoming input events
-        lh.onInput { input in
-            log.info("Got input \(input)")
-        }
-
         // Connect to the lighthouse server
         try await lh.connect()
         log.info("Connected to the lighthouse")
 
-        // Request a stream of events
-        try await lh.requestStream()
+        // Handle incoming input events
+        Task {
+            let stream = try await lh.streamModel()
+            for await message in stream {
+                if case let .inputEvent(input) = message.payload {
+                    log.info("Got input \(input)")
+                }
+            }
+        }
 
         // Repeatedly send colored frames to the lighthouse
         while true {
             log.info("Sending frame")
-            try await lh.send(frame: Frame(fill: .random()))
+            try await lh.putModel(frame: Frame(fill: .random()))
             try await Task.sleep(nanoseconds: 1_000_000_000)
         }
     }

--- a/Sources/LighthouseProtocol/Protocol.swift
+++ b/Sources/LighthouseProtocol/Protocol.swift
@@ -75,6 +75,11 @@ public struct ClientMessage: Codable {
     }
 }
 
+/// An error originating from the server.
+public enum ServerError: Error, Hashable {
+    case serverError(code: Int, message: String?)
+}
+
 /// A message originating from the lighthouse server.
 public struct ServerMessage: Codable {
     public enum CodingKeys: String, CodingKey {
@@ -103,5 +108,12 @@ public struct ServerMessage: Codable {
         self.warnings = warnings
         self.response = response
         self.payload = payload
+    }
+
+    /// Checks this response and returns only if successful.
+    public func check() throws {
+        if code != 200 {
+            throw ServerError.serverError(code: code, message: response)
+        }
     }
 }


### PR DESCRIPTION
### Fixes #5

This makes the Lighthouse client both more flexible and more ergonomic to use by leveraging `AsyncSequence` and `for-await` loops.

The API is also aligned closely with the Rust API changes introduced in https://github.com/fwcd/lighthouse-rust/commit/2a0e0d7465c40a172147a710cfea57f347601fd1.